### PR TITLE
Stop sessions from freezing up when send_email is called

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ web:
   links:
     - db
     - redis
+    - rabbitmq
   expose:
     - "8282"
   volumes:
@@ -33,6 +34,7 @@ db:
     - POSTGRES_DB=uber_db
 redis:
   image: redis
+  container_name: rams_redis
 rabbitmq:
   container_name: rams_rabbit
   image: rabbitmq:alpine

--- a/sideboard-development.ini
+++ b/sideboard-development.ini
@@ -6,6 +6,9 @@ default_url = "/rams"
 server.socket_host = 0.0.0.0
 server.socket_port = 8282
 tools.sessions.timeout = 4320  # 30 days (in minutes)
+tools.sessions.storage_type = redis
+tools.sessions.host = rams_redis
+tools.sessions.port = 6379
 
 [loggers]
 root = "DEBUG"


### PR DESCRIPTION
The web container needs to be linked to rabbitmq so it can send emails -- see https://github.com/magfest/ubersystem/issues/3197. Additionally, we configured sideboard to use redis for sessions.