### PR TITLE
Stop celery-beat from failing if you restart the container

### DIFF
--- a/uber-wrapper.sh
+++ b/uber-wrapper.sh
@@ -5,7 +5,7 @@ if [ "$1" = 'uber' ]; then
     /app/env/bin/python3 /app/sideboard/sep.py alembic upgrade heads
     /app/env/bin/python3 /app/sideboard/run_server.py
 elif [ "$1" = 'celery-beat' ]; then
-    /app/env/bin/celery -A uber.tasks beat
+    /app/env/bin/celery -A uber.tasks beat --pidfile=
 elif [ "$1" = 'celery-worker' ]; then
     /app/env/bin/celery -A uber.tasks worker
 fi


### PR DESCRIPTION
If you used docker-compose restart for the celery-beat container, it would think it's already running because it saw the old pidfile. That would prevent it from running the automated emails task ever again, so we fixed it. Fixes https://github.com/MidwestFurryFandom/mff-rams-plugin/issues/40 (the part that can be fixed, anyway).