### PR TITLE
Added a line to the docker file to install Ghostscript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM vmearl/rams:magfest-merge
 
+# install ghostscript
+RUN apt-get update && apt-get install -y ghostscript && rm -rf /var/lib/apt/lists/*
+
 ADD src plugins/
 ADD sideboard-development.ini ./development.ini
 ADD uber-wrapper.sh /usr/local/bin/


### PR DESCRIPTION
Ghostscript is required in order for barcodes to show up.  This update installs that package into the container that hosts RAMS.  No update to requirements.txt is needed, since the ghostscript python package is already a dependency, it just needs the backing C libraries.

Please let me know if you see any problems with this approach.