### PR TITLE
Use latest Docker image and remove extra plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ src
 nginx/certs
 uber-development.ini
 **/*.env
+.history/
+*.swp
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmearl/rams:magfest-merge
+FROM vmearl/sideboard:latest
 
 # install ghostscript
 RUN apt-get update && apt-get install -y ghostscript && rm -rf /var/lib/apt/lists/*

--- a/sideboard-development.ini
+++ b/sideboard-development.ini
@@ -1,5 +1,5 @@
 debug = false
-priority_plugins = "uber","art_show","badge_printing"
+priority_plugins = "uber",
 default_url = "/rams"
 
 


### PR DESCRIPTION
We were going through two Docker images but then repeated the steps of the interim Docker image anyway, so this removes the Dockerfile in the middle. Also updates sideboard-development as the art and badge printing plugins are now integrated into the codebase.